### PR TITLE
feat(vault): add cfxOnly to public vault

### DIFF
--- a/packages/background/src/db-schema.js
+++ b/packages/background/src/db-schema.js
@@ -6,6 +6,9 @@ const schema = {
     data: {
       doc: 'Encrypted vault data',
     },
+    cfxOnly: {
+      doc: 'If this vault is only for conflux chain',
+    },
     accounts: {
       doc: 'Accounts belong to this vault',
       many: true,

--- a/packages/rpcs/wallet_addVault/index.js
+++ b/packages/rpcs/wallet_addVault/index.js
@@ -5,11 +5,12 @@ import {
   privateKey,
   base32AccountMainnetAddress,
   base32AccountTestnetAddress,
-  hexAccountAddress,
+  ethHexAddress,
   password,
 } from '@cfxjs/spec'
 import {encrypt, decrypt} from 'browser-passworder'
 import {partial, compL} from '@cfxjs/compose'
+import {validateBase32Address, decode} from '@cfxjs/base32-address'
 
 export const NAME = 'wallet_addVault'
 
@@ -22,7 +23,7 @@ const addressSchema = [
     'address',
     [
       or,
-      hexAccountAddress,
+      ethHexAddress,
       base32AccountMainnetAddress,
       base32AccountTestnetAddress,
     ],
@@ -38,6 +39,12 @@ export const permissions = {
   db: ['createVault'],
 }
 
+const processAddress = address => {
+  const isBase32 = validateBase32Address(address)
+  if (!isBase32) return {address, cfxOnly: false}
+  return {cfxOnly: true, address: decode(address).hexAddress}
+}
+
 export async function main({
   db: {createVault},
   params: {password, mnemonic, privateKey, address},
@@ -46,24 +53,33 @@ export async function main({
 }) {
   if (!(await wallet_validatePassword({password})))
     throw Err.InvalidParams('Invalid password')
-  const keyring = mnemonic || privateKey || address
-  let keyringType
-  if (address) keyringType = 'pub'
-  if (privateKey) keyringType = 'pk'
-  if (mnemonic) keyringType = 'hd'
-  const encrypted = await encrypt(password, keyring)
+
+  const vault = {}
+  vault.data = mnemonic || privateKey || address
+  if (privateKey) vault.type = 'pk'
+  else if (mnemonic) vault.type = 'hd'
+  else if (address) {
+    const validateResult = processAddress(address, Err)
+    vault.type = 'pub'
+    vault.data = validateResult.address
+    vault.cfxOnly = validateResult.cfxOnly
+  }
+
   const vaults = await wallet_getVaults()
   const anyDuplicateVaults = await Promise.all(
     vaults.map(
       compL(
         v => v.data,
         partial(decrypt, password), // decrypt vault, returns stringified { data:..., type:...}
-        p => p.then(data => data === keyring),
+        p => p.then(data => data === vault.data),
       ),
     ),
   )
+
   if (anyDuplicateVaults.includes(true))
     throw Err.InvalidParams('Duplicate credential')
 
-  createVault({data: encrypted, type: keyringType})
+  vault.data = await encrypt(password, vault.data)
+
+  createVault(vault)
 }

--- a/packages/rpcs/wallet_addVault/package.json
+++ b/packages/rpcs/wallet_addVault/package.json
@@ -4,6 +4,7 @@
   "type": "module",
   "version": "0.0.0",
   "dependencies": {
+    "@cfxjs/base32-address": "workspace:packages/base32-address",
     "@cfxjs/spec": "workspace:packages/spec",
     "browser-passworder": "^2.0.3"
   }

--- a/packages/spec/index.js
+++ b/packages/spec/index.js
@@ -1,7 +1,12 @@
 export * from './src/spec.js' // eslint-disable-line import/export
 import {INTERNAL_CONTRACTS_HEX_ADDRESS, NULL_HEX_ADDRESS} from 'consts'
 
-import {defRestSchemas, defBase32AddressSchemaFactory, or} from './src/spec.js'
+import {
+  defRestSchemas,
+  defBase32AddressSchemaFactory,
+  or,
+  integer,
+} from './src/spec.js'
 
 import {
   randomHexAddress,
@@ -47,5 +52,6 @@ export const defBase32AddressSchema = (...args) => {
   )
 }
 
+export const dbid = integer
 export const base32AccountMainnetAddress = defBase32AddressSchema('user', 1029)
 export const base32AccountTestnetAddress = defBase32AddressSchema('user', 1)

--- a/yarn.lock
+++ b/yarn.lock
@@ -951,6 +951,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@cfxjs/wallet_addVault@workspace:packages/rpcs/wallet_addVault"
   dependencies:
+    "@cfxjs/base32-address": "workspace:packages/base32-address"
     "@cfxjs/spec": "workspace:packages/spec"
     browser-passworder: ^2.0.3
   languageName: unknown


### PR DESCRIPTION
if user giving a base32 address vault, mark it as cfx only vault, don't create ethHexAddress on the corresponding account when creating it from the vault

For hex address public vault, store the original hex address. Create a normal account with ethHexAddress and convert it to 0x-prefixed address as cfxHexAddress.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/helios/19)
<!-- Reviewable:end -->
