### PR TITLE
fix: compatible provider api

### DIFF
--- a/.env
+++ b/.env
@@ -1,3 +1,3 @@
 # shared basic environment variable
 # the build tool will load this file with any NODE_ENV
-SNOWPACK_PUBLIC_FLUENT_VERSION=1.3.0
+SNOWPACK_PUBLIC_FLUENT_VERSION=1.3.1

--- a/.yarn/versions/2231a8d3.yml
+++ b/.yarn/versions/2231a8d3.yml
@@ -1,0 +1,8 @@
+releases:
+  "@fluent-wallet/db": patch
+  "@fluent-wallet/provider-api": patch
+
+declined:
+  - helios-background
+  - helios-inpage
+  - "@fluent-wallet/use-rpc"

--- a/packages/db/src/main/cfxjs/db/queries.cljs
+++ b/packages/db/src/main/cfxjs/db/queries.cljs
@@ -401,7 +401,9 @@
         authed-app           (q '[:find [?app ...]
                                   :in $ ?acc
                                   :where
-                                  [?app :app/account ?acc]] acc)
+                                  [?app :app/account ?acc]
+                                  (not [?app :app/currentAccount ?acc])]
+                                acc)
         authed-app-reselects (reduce (fn [ac app-eid]
                                        (concat ac [[:db.fn/retractAttribute app-eid :app/currentAccount]
                                                    [:db/add app-eid :app/currentAccount acc]]))

--- a/packages/ui/provider-api/index.js
+++ b/packages/ui/provider-api/index.js
@@ -57,6 +57,7 @@ class Provider extends SafeEventEmitter {
         'chainChanged',
         'message',
       ],
+      streamCacheLast: false,
     })
     this.#s = stream
     this.#send = send
@@ -105,6 +106,7 @@ class PortalProvider extends SafeEventEmitter {
         'chainChanged',
         'message',
       ],
+      streamCacheLast: true,
     })
     this.#s = stream
     this.#send = send
@@ -126,6 +128,8 @@ class PortalProvider extends SafeEventEmitter {
           this._networkVersion = networkId.toString(10)
           this.confluxJS.networkId = networkId
           this.confluxJS.wallet.networkId = networkId
+          this.emit('chainChanged', result)
+          this.emit('networkChanged', networkId)
         })
         this.request({method: 'cfx_accounts'})
           .then(result => {


### PR DESCRIPTION
1. emit network events on start
2. cache last item in compatible provide event stream
3. only emit accountsChanged event when the app/currentAccount do chagned

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/helios/724)
<!-- Reviewable:end -->
