### PR TITLE
feat: support ledger eSpace app

### DIFF
--- a/.yarn/versions/997beb9d.yml
+++ b/.yarn/versions/997beb9d.yml
@@ -1,0 +1,10 @@
+releases:
+  "@fluent-wallet/ledger": patch
+
+declined:
+  - helios-popup
+  - "@fluent-wallet/cfx_sign-transaction"
+  - "@fluent-wallet/cfx_sign-tx-with-ledger-nano-s"
+  - "@fluent-wallet/eth_sign-transaction"
+  - "@fluent-wallet/eth_sign-tx-with-ledger-nano-s"
+  - "@fluent-wallet/wallet_import-hardware-wallet-account-group-or-account"

--- a/packages/ledger/const.js
+++ b/packages/ledger/const.js
@@ -1,6 +1,7 @@
 export const LEDGER_APP_NAME = {
   CONFLUX: 'Conflux',
   ETHEREUM: 'Ethereum',
+  ESPACE: 'Conflux eSpace',
 }
 /**
  * https://developer.mozilla.org/en-US/docs/Web/API/USBDevice/productID

--- a/packages/ledger/ethereum.js
+++ b/packages/ledger/ethereum.js
@@ -113,13 +113,21 @@ export default class Ethereum {
     return Boolean(devices.length)
   }
 
-  async isAppOpen() {
+  /**
+   * whether the ledger app for the evm-based or ethereum chain is open
+   * You can sign the transaction in the evm-based chain with the evm-based app or the ethereum app
+   * @param {String} chainName:'CONFLUX','ETHEREUM','ESPACE'
+   * @returns boolean
+   */
+  async isAppOpen(chainName) {
     try {
       const isAuthed = await this.isDeviceAuthed()
       if (!isAuthed) return false
       const config = await this.getAppConfiguration()
-      const {name} = config
-      return name === LEDGER_APP_NAME.ETHEREUM
+      const name = config?.name || ''
+      return (
+        name === LEDGER_APP_NAME[chainName] || name === LEDGER_APP_NAME.ETHEREUM
+      )
     } catch (error) {
       return false
     } finally {
@@ -127,14 +135,19 @@ export default class Ethereum {
     }
   }
 
-  async openApp() {
+  /**
+   *
+   * @param {String} ledgerAppName: the name of the ledger app  which you want to open
+   * @returns boolean
+   */
+  async openApp(ledgerAppName) {
     try {
       await this.transport?.send(
         LEDGER_CLA,
         INS.OPEN_APP,
         0x00,
         0x00,
-        Buffer.from(LEDGER_APP_NAME.ETHEREUM, 'ascii'),
+        Buffer.from(ledgerAppName || LEDGER_APP_NAME.ETHEREUM, 'ascii'),
       )
       return true
     } catch (error) {


### PR DESCRIPTION
some APIs have already changed, but they are compatible

- `isAppOpen(chainName)`
- `openApp(ledgerAppName)`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/helios/1009)
<!-- Reviewable:end -->
