### PR TITLE
fix(PORTAL-3114):switch network error

### DIFF
--- a/.yarn/versions/59c47033.yml
+++ b/.yarn/versions/59c47033.yml
@@ -1,0 +1,2 @@
+declined:
+  - "@fluent-wallet/wallet_set-app-current-network"

--- a/packages/rpcs/wallet_setAppCurrentNetwork/index.js
+++ b/packages/rpcs/wallet_setAppCurrentNetwork/index.js
@@ -43,6 +43,7 @@ export const main = ({
       account: app.currentAccount.eid,
       network: nextNetwork.eid,
     })
-    post({event: 'accountsChanged', params: [addr.value]})
+    //sometimes, if you authorize a hardware ledger account under ethereum to dapp, when you switch to conflux network, you cannot get addr
+    post({event: 'accountsChanged', params: [addr?.value]})
   }
 }


### PR DESCRIPTION
sometimes, when you authorize a hardware ledger account under ethereum to a dapp site, when you switch to conflux network, there will be a error: you cannot get addr

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/helios/1038)
<!-- Reviewable:end -->
