### PR TITLE
fix: estimate error

### DIFF
--- a/.yarn/versions/996b1940.yml
+++ b/.yarn/versions/996b1940.yml
@@ -1,0 +1,2 @@
+declined:
+  - "@fluent-wallet/cfx_sign-transaction"

--- a/packages/rpcs/cfx_signTransaction/index.js
+++ b/packages/rpcs/cfx_signTransaction/index.js
@@ -105,7 +105,6 @@ export const main = async args => {
 
   if (!newTx.chainId) newTx.chainId = network.chainId
   if (newTx.data === '0x') newTx.data = undefined
-  if (!newTx.gasPrice) newTx.gasPrice = await cfx_gasPrice()
 
   if (!newTx.value) newTx.value = '0x0'
 
@@ -130,7 +129,6 @@ export const main = async args => {
       if (!newTx.storageLimit) newTx.storageLimit = '0x0'
     }
   }
-
   if (!newTx.gas || !newTx.storageLimit) {
     const {gasLimit, storageCollateralized} =
       await cfx_estimateGasAndCollateral({errorFallThrough: true}, [
@@ -140,6 +138,8 @@ export const main = async args => {
     if (!newTx.gas) newTx.gas = gasLimit
     if (!newTx.storageLimit) newTx.storageLimit = storageCollateralized
   }
+
+  if (!newTx.gasPrice) newTx.gasPrice = await cfx_gasPrice()
 
   let raw
   if (fromAddr.account.accountGroup.vault.type === 'hw') {

--- a/packages/rpcs/cfx_signTransaction/index.js
+++ b/packages/rpcs/cfx_signTransaction/index.js
@@ -129,6 +129,7 @@ export const main = async args => {
       if (!newTx.storageLimit) newTx.storageLimit = '0x0'
     }
   }
+
   if (!newTx.gas || !newTx.storageLimit) {
     const {gasLimit, storageCollateralized} =
       await cfx_estimateGasAndCollateral({errorFallThrough: true}, [


### PR DESCRIPTION
fullnode change the estimate rpc, when tx data not including gasPrice and gasLimit will estimate with gasPrice`1drip` and gasLimit `1500w`, otherwise, will estimate with supplied data. So should estimate before cfx_gasPrice, avoiding estimate with gasPrice 1Gdrip and return an error.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/helios/1039)
<!-- Reviewable:end -->
