### PR TITLE
feat: handle dapp auth accounts on account hidden

### DIFF
--- a/.yarn/versions/497814b4.yml
+++ b/.yarn/versions/497814b4.yml
@@ -1,0 +1,6 @@
+releases:
+  "@fluent-wallet/db": patch
+  "@fluent-wallet/wallet_update-account": patch
+
+declined:
+  - helios-background

--- a/.yarn/versions/497814b4.yml
+++ b/.yarn/versions/497814b4.yml
@@ -1,5 +1,6 @@
 releases:
   "@fluent-wallet/db": patch
+  "@fluent-wallet/wallet_set-current-network": patch
   "@fluent-wallet/wallet_update-account": patch
 
 declined:

--- a/packages/db/src/main/cfxjs/db/queries.cljs
+++ b/packages/db/src/main/cfxjs/db/queries.cljs
@@ -591,6 +591,16 @@
     (t txns)
     true))
 
+(defn get-connected-sites-without-apps
+  "Get sites that not authed as an app but has the post method defined"
+  []
+  (->> (q '[:find [?site ...]
+            :where
+            [?site :site/post _]
+            (not [?app :app/site ?site])])
+       (map (partial e :site))
+       clj->js))
+
 (defn get-apps-with-different-selected-network
   "given the to-be-selected network, return all apps with different selected network"
   [nextnet]
@@ -1728,6 +1738,7 @@
               :getAppAnotherAuthedNoneHWAccount    get-app-another-authed-none-hw-account
               :updateAccountWithHiddenHandler      update-account
               :isLastNoneHWAccount                 is-last-none-hw-account
+              :getConnectedSitesWithoutApps         get-connected-sites-without-apps
 
               :queryqueryApp              get-apps
               :queryqueryAddress          get-address

--- a/packages/db/src/main/cfxjs/db/queries.cljs
+++ b/packages/db/src/main/cfxjs/db/queries.cljs
@@ -613,6 +613,94 @@
        (not [(= ?type "hw")])]
      appId))
 
+(defn get-hidden-account-apps
+  "Given to-hide accountId, find apps which authed this account,
+  return [txs sideeffects] to handle the hidden account"
+  [{:keys [accountId]}]
+  (let [apps-data
+        (q '[:find ?app (count-distinct ?all-acc) ?current-acc
+             :in $ ?acc
+             :where
+             [?app :app/account ?acc]
+             [?app :app/account ?all-acc]
+             [?app :app/currentAccount ?curacc]
+             [(= ?curacc ?acc) ?current-acc]]
+           accountId)
+
+        ->txs
+        ;; txs: transactions send to db
+        ;; sideeffects: methods to call in js to notify app
+        (fn [[txs sideeffects] [app-id authed-acc-count current-acc?]]
+          (bc/cond
+            ;; hidden acc is the only and current authed acc of app
+            ;; delete the app
+            (and current-acc? (= authed-acc-count 1))
+            [txs (conj sideeffects [:wallet_deleteApp {:appId app-id}])]
+
+            ;; hidden acc is not current acc of dapp (more than 1 authed acc)
+            ;; unauth acc
+            (not current-acc?)
+            [(conj txs [:db/retract app-id :app/account accountId]) sideeffects]
+
+            ;; hidden acc is current acc of app and app has multiple authed acc
+            ;; switch current acc, unauth acc
+            :let
+            [app-switch-acc-data
+             (q '[:find ?app (distinct ?next-acc)
+                  :in $ ?acc
+                  :where
+                  [?app :app/currentAccount ?acc]
+                  [?app :app/account ?next-acc]
+                  (not [(= ?next-acc ?acc)])
+                  ;; make sure next acc has addr in current net
+                  [?next-acc :account/address ?addr]
+                  [?addr :address/network ?net]
+                  [?net :network/selected true]]
+                accountId)
+
+             ->txs
+             (fn [[txs sideeffects] [app-id next-acc-ids]]
+               (if (first next-acc-ids)
+                 ;; has next acc
+                 [(conj txs [:db/retract app-id :app/account accountId])
+                  (conj sideeffects [:wallet_setAppCurrentAccount {:appId app-id :accountId (first next-acc-ids)}])]
+                 ;; no next acc (next authed acc is hw acc and no addr under current net)
+                 [txs (conj sideeffects [:wallet_deleteApp {:appId app-id}])]))]
+
+            :else
+            (reduce ->txs [txs sideeffects] app-switch-acc-data)))]
+    (reduce ->txs [[] []] apps-data)))
+
+(defn update-account [{:keys [accountId nickname hidden offline]}]
+  (let [acc               (p [:account/hidden ;; :account/selected
+                              ]
+                             accountId)
+        newly-hidden?     (and hidden (not (:account/hidden acc)))
+        ;; cur-acc?          (:account/selected acc)
+        [txs sideeffects] (if newly-hidden? (get-hidden-account-apps {:accountId accountId}) [[] []])
+        update-acc-tx     (-> {:db/id accountId}
+                              (enc/assoc-some :account/nickname nickname)
+                              (enc/assoc-some :account/hidden hidden)
+                              (enc/assoc-some :account/offline offline))
+        txs               (conj txs update-acc-tx)]
+    (t txs)
+    (clj->js sideeffects)))
+
+(defn is-last-none-hw-account
+  "Check if acc is last none hw acc"
+  [{:keys [accountId]}]
+  (q '[:find ?acc .
+       :in $ ?a
+       :where
+       [?acc :account/index]
+       (not [(= ?acc ?a)])
+       (not [?acc :account/hidden true])
+       [?g :accountGroup/account ?acc]
+       [?g :accountGroup/vault ?v]
+       [?v :vault/type ?type]
+       (not [(= ?type "hw")])]
+     (not accountId)))
+
 (defn upsert-app-permissions
   [opt]
   (let [{:keys [siteId
@@ -1637,7 +1725,9 @@
               :setPreferences                      set-preferences
               :getPreferences                      get-preferences
               :getAppsWithDifferentSelectedNetwork get-apps-with-different-selected-network
-              :getAppAnotherAuthedNoneHWAccount get-app-another-authed-none-hw-account
+              :getAppAnotherAuthedNoneHWAccount    get-app-another-authed-none-hw-account
+              :updateAccountWithHiddenHandler      update-account
+              :isLastNoneHWAccount                 is-last-none-hw-account
 
               :queryqueryApp              get-apps
               :queryqueryAddress          get-address

--- a/packages/rpcs/wallet_setCurrentNetwork/index.js
+++ b/packages/rpcs/wallet_setCurrentNetwork/index.js
@@ -14,6 +14,7 @@ export const permissions = {
     'setCurrentNetwork',
     'getNetworkById',
     'getAppsWithDifferentSelectedNetwork',
+    'getConnectedSitesWithoutApps',
   ],
 }
 
@@ -31,7 +32,12 @@ function shouldGivenCrossNetworkAddressLookupPermissonsBasedOnNetworkChange(
 
 export const main = async ({
   Err: {InvalidParams},
-  db: {setCurrentNetwork, getNetworkById, getAppsWithDifferentSelectedNetwork},
+  db: {
+    setCurrentNetwork,
+    getNetworkById,
+    getAppsWithDifferentSelectedNetwork,
+    getConnectedSitesWithoutApps,
+  },
   rpcs: {wallet_setAppCurrentNetwork, wallet_requestPermissions},
   params: networks,
   network,
@@ -69,6 +75,10 @@ export const main = async ({
       return true
     }),
   )
+
+  getConnectedSitesWithoutApps().forEach(site => {
+    site.post({event: 'chainChanged', params: nextNetwork.chainId})
+  })
 
   Sentry.setTag('current_network', nextNetwork.name)
 }

--- a/packages/rpcs/wallet_updateAccount/package.json
+++ b/packages/rpcs/wallet_updateAccount/package.json
@@ -4,7 +4,6 @@
   "main": "index.js",
   "version": "0.0.9",
   "dependencies": {
-    "@fluent-wallet/checks": "workspace:packages/checks",
     "@fluent-wallet/spec": "workspace:packages/spec"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7355,7 +7355,6 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@fluent-wallet/wallet_update-account@workspace:packages/rpcs/wallet_updateAccount"
   dependencies:
-    "@fluent-wallet/checks": "workspace:packages/checks"
     "@fluent-wallet/spec": "workspace:packages/spec"
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
1. delete app if is only authed acc
2. switch acc and revoke auth if is selected and authed acc
3. revoke auth if is non-selected authed acc
4. switch to first authed acc that has addr under current network
5. check if is last none hw account before hidden

PORTAL-3138

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/helios/1063)
<!-- Reviewable:end -->
