### PR TITLE
fix: only show notifications if failed none silently

### DIFF
--- a/.yarn/versions/e1619a66.yml
+++ b/.yarn/versions/e1619a66.yml
@@ -1,0 +1,6 @@
+releases:
+  "@fluent-wallet/wallet_handle-unfinished-cfx-tx": patch
+  "@fluent-wallet/wallet_handle-unfinished-eth-tx": patch
+
+declined:
+  - helios-background


### PR DESCRIPTION
1. we set tx to failed if tx with same nonce get confirmed, this action
won't trigger the notification
2. setTxXXX fns will check tx status before make the tx, and will return
nil(undefined) if is tx in end state already.
3. this won't fix PORTAL-3357, check the detail in PORTAL-3357 for more

PORTAL-3357

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/helios/1220)
<!-- Reviewable:end -->
