### PR TITLE
fix: external tx logic affected by none confirmed tx

### DIFF
--- a/.yarn/versions/b05d9237.yml
+++ b/.yarn/versions/b05d9237.yml
@@ -1,0 +1,5 @@
+releases:
+  "@fluent-wallet/db": patch
+
+declined:
+  - helios-background


### PR DESCRIPTION
don't count none confirmed tx and external tx when fetching external tx
from scan

PORTAL-3390

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/helios/1239)
<!-- Reviewable:end -->
